### PR TITLE
feat(map): add map popup content and dynamic styling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4,3 +4,34 @@
     light --default,
     dark --prefersdark;
 }
+
+.maplibregl-popup-close-button {
+  @apply px-2;
+}
+html[data-theme="dark"] {
+  .maplibregl-popup-content {
+    @apply text-white bg-gray-800;
+  }
+  .maplibregl-popup-tip {
+    @apply border-t-gray-800;
+  }
+  .maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+  .maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip,
+  .maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip {
+    @apply border-t-gray-800;
+  }
+
+  .maplibregl-popup-anchor-top .maplibregl-popup-tip,
+  .maplibregl-popup-anchor-top-right .maplibregl-popup-tip,
+  .maplibregl-popup-anchor-top-left .maplibregl-popup-tip {
+    @apply border-b-gray-800;
+  }
+
+  .maplibregl-popup-anchor-left .maplibregl-popup-tip {
+    @apply border-r-gray-800;
+  }
+
+  .maplibregl-popup-anchor-right .maplibregl-popup-tip {
+    @apply border-l-gray-800;
+  }
+}

--- a/components/app/map.client.vue
+++ b/components/app/map.client.vue
@@ -29,14 +29,30 @@ onMounted(() => {
       :coordinates="[point.long, point.lat]"
     >
       <template #marker>
-        <div class="tooltip tooltip-top" :data-tip="point.label">
+        <div
+          class="tooltip tooltip-top hover:cursor-pointer"
+          :data-tip="point.name"
+          :class="{
+            'tooltip-open': point === mapStore.selectedPoint,
+          }"
+          @mouseleave="mapStore.selectedPointWithoutFlyTo(null)"
+          @mouseenter="mapStore.selectedPointWithoutFlyTo(point)"
+        >
           <Icon
             name="tabler:map-pin-filled"
             size="30"
-            class="text-primary"
+            :class="point === mapStore.selectedPoint ? 'text-accent' : 'text-secondary'"
           />
         </div>
       </template>
+      <MglPopup>
+        <h3 class="text-xl">
+          {{ point.name }}
+        </h3>
+        <p v-if="point.description" class="text-sm">
+          {{ point.description }}
+        </p>
+      </MglPopup>
     </MglMarker>
   </MglMap>
 </template>

--- a/components/sidebar-button.vue
+++ b/components/sidebar-button.vue
@@ -4,6 +4,7 @@ const props = defineProps<{
   icon: string;
   label: string;
   showLabel: boolean;
+  iconColor?: "text-accent" | "text-primary" | "text-secondary";
 }>();
 
 const route = useRoute();
@@ -20,7 +21,11 @@ const route = useRoute();
       :class="{ 'bg-base-200': route.path === props.href, 'justify-center': !props.showLabel, 'justify-start': props.showLabel }"
       class="flex gap-2 p-2 hover:bg-base-300 hover:cursor-pointer flex-nowrap"
     >
-      <Icon :name="props.icon" size="24" />
+      <Icon
+        :name="props.icon"
+        size="24"
+        :class="iconColor"
+      />
       <Transition name="grow">
         <span v-if="props.showLabel" class="ml-2">{{ props.label }}</span>
       </Transition>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,5 +13,6 @@ export type LatLongItem = {
 };
 export type MapPoint = {
   id: number;
-  label: string;
+  name: string;
+  description: string | null;
 } & LatLongItem;

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -2,6 +2,7 @@
 const isSidebarOpen = ref(true);
 const route = useRoute();
 const sidebarStore = useSidebarStore();
+const mapStore = useMapStore();
 const locationsStore = useLocationsStore();
 
 onMounted(() => {
@@ -64,6 +65,9 @@ function toggleSidebar() {
             :href="item.href"
             :icon="item.icon"
             :label="item.label"
+            :icon-color="mapStore.selectedPoint === item.location ? 'text-accent' : undefined"
+            @mouseenter="mapStore.selectedPoint = item.location ?? null"
+            @mouseleave="mapStore.selectedPoint = null"
           />
         </div>
         <div class="divider my-2" />

--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 const locationsStore = useLocationsStore();
 const { locations, status } = storeToRefs(locationsStore);
-
+const mapStore = useMapStore();
 onMounted(() => {
   locationsStore.refresh();
 });
@@ -19,7 +19,13 @@ onMounted(() => {
       <div
         v-for="location in locations"
         :key="location.id"
-        class="card card-compact bg-base-300 w-72 h-40 shrink-0"
+        class="card card-compact bg-base-300 border-2 w-72 h-40 mb-2 shrink-0 hover:cursor-pointer"
+        :class="{
+          'border-accent': location === mapStore.selectedPoint,
+          'border-transparent': location !== mapStore.selectedPoint,
+        }"
+        @mouseenter="mapStore.selectedPoint = location"
+        @mouseleave="mapStore.selectedPoint = null"
       >
         <div class="card-body">
           <h3 class="card-title">

--- a/stores/locations.ts
+++ b/stores/locations.ts
@@ -14,13 +14,9 @@ export const useLocationsStore = defineStore("useLocationsStore", () => {
         label: location.name,
         icon: "tabler:map-pin-filled",
         href: `/dashboard/${location.id}`,
+        location,
       }));
-      mapStore.mapPoints = data.value?.map(location => ({
-        id: location.id,
-        label: location.name,
-        lat: location.lat,
-        long: location.long,
-      }));
+      mapStore.mapPoints = data.value;
     }
     sidebarStore.loading = status.value === "pending";
   });

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -1,24 +1,54 @@
+import type { LngLatBounds } from "maplibre-gl";
+
 import type { MapPoint } from "~/lib/types";
 
 export const useMapStore = defineStore("useMapStore", () => {
   const mapPoints = ref<MapPoint[]>([]);
+  const selectedPoint = ref<MapPoint | null>(null);
+  const shouldFlyTo = ref(false);
+
+  function selectedPointWithoutFlyTo(point: MapPoint | null) {
+    shouldFlyTo.value = false;
+    selectedPoint.value = point;
+  }
   async function init() {
     const { useMap } = await import("@indoorequal/vue-maplibre-gl");
     const { LngLatBounds } = await import("maplibre-gl");
 
     const map = useMap();
+    const padding = 60;
+
+    let bounds: LngLatBounds | null = null;
     effect(() => {
       const firstPoint = mapPoints.value[0];
       if (!firstPoint)
         return;
-      const bounds = mapPoints.value.reduce((bounds, point) => {
+      bounds = mapPoints.value.reduce((bounds, point) => {
         return bounds.extend([point.long, point.lat]);
       }, new LngLatBounds([firstPoint.long, firstPoint.lat], [firstPoint.long, firstPoint.lat]));
-      map.map?.fitBounds(bounds, { padding: 60 });
+      map.map?.fitBounds(bounds, { padding });
+    });
+
+    effect(() => {
+      if (selectedPoint.value) {
+        // TODO: add a setting to disable the animations
+        if (shouldFlyTo.value) {
+          map.map?.flyTo({
+            center: [selectedPoint.value.long, selectedPoint.value.lat],
+            speed: 0.8,
+          });
+        }
+        shouldFlyTo.value = true;
+      }
+      else if (bounds) {
+        map.map?.fitBounds(bounds, { padding });
+      }
     });
   }
   return {
     init,
     mapPoints,
+    selectedPoint,
+    selectedPointWithoutFlyTo,
   };
 });

--- a/stores/sidebar.ts
+++ b/stores/sidebar.ts
@@ -1,8 +1,11 @@
+import type { MapPoint } from "~/lib/types";
+
 export type SidebarItem = {
   id: string;
   label: string;
   icon: string;
   href: string;
+  location?: MapPoint | null;
 };
 
 export const useSidebarStore = defineStore("useSidebarStore", () => {


### PR DESCRIPTION
closes #29
- Added popup component with point name and description
- Implemented dark mode styling for map popups
- Added hover effects and selected point state management
- Improved map marker interactions and visual feedback

BREAKING CHANGE: MapPoint type properties changed (label -> name, added description)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map popups now display a point’s name and description, with improved appearance in dark mode.
  * Sidebar and dashboard items highlight and synchronize with the selected map point on hover for better visual feedback.
  * Marker tooltips and icons dynamically reflect selection state for enhanced interactivity.

* **Enhancements**
  * Added support for dynamic icon colors in sidebar buttons.
  * Improved map navigation by separating fly-to animations from simple selection.

* **Style**
  * Updated map popup styles for better readability and consistency, especially in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->