### PR TITLE
feat(map): enable adding new points via drag and double-click on the map

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -79,8 +79,8 @@ function toggleSidebar() {
         />
       </div>
     </div>
-    <div class="flex-1 overflow-auto">
-      <div class="flex flex-col size-full">
+    <div class="flex-1 overflow-auto bg-base-200">
+      <div class="flex size-full" :class="{ 'flex-col': route.path !== '/dashboard/add' }">
         <NuxtPage />
         <AppMap class="flex-1" />
       </div>

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -5,12 +5,8 @@ import type { MapPoint } from "~/lib/types";
 export const useMapStore = defineStore("useMapStore", () => {
   const mapPoints = ref<MapPoint[]>([]);
   const selectedPoint = ref<MapPoint | null>(null);
-  const shouldFlyTo = ref(false);
+  const addedPoint = ref<MapPoint | null>(null);
 
-  function selectedPointWithoutFlyTo(point: MapPoint | null) {
-    shouldFlyTo.value = false;
-    selectedPoint.value = point;
-  }
   async function init() {
     const { useMap } = await import("@indoorequal/vue-maplibre-gl");
     const { LngLatBounds } = await import("maplibre-gl");
@@ -29,26 +25,23 @@ export const useMapStore = defineStore("useMapStore", () => {
       map.map?.fitBounds(bounds, { padding });
     });
 
-    effect(() => {
-      if (selectedPoint.value) {
-        // TODO: add a setting to disable the animations
-        if (shouldFlyTo.value) {
-          map.map?.flyTo({
-            center: [selectedPoint.value.long, selectedPoint.value.lat],
-            speed: 0.8,
-          });
-        }
-        shouldFlyTo.value = true;
+    watch(addedPoint, (newValue, oldValue) => {
+      if (newValue && !oldValue) {
+        map.map?.flyTo({
+          center: [newValue.long, newValue.lat],
+          speed: 0.8,
+          zoom: 6,
+        });
       }
-      else if (bounds) {
-        map.map?.fitBounds(bounds, { padding });
-      }
+    }, {
+      immediate: true,
     });
   }
   return {
     init,
     mapPoints,
     selectedPoint,
-    selectedPointWithoutFlyTo,
+
+    addedPoint,
   };
 });


### PR DESCRIPTION
This PR introduces new interactive features for adding map points, including drag-and-drop functionality and double-click selection. The changes enhance the user interface by adding visual markers and tooltips to guide users in placing points on the map.


closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now add a point to the map by double-clicking or dragging a marker, with the map centering on the newly added point.
  * The add location form now synchronizes with the map, allowing users to set coordinates interactively rather than entering them manually.

* **Improvements**
  * The dashboard layout dynamically adjusts based on the current route.
  * Latitude and longitude values are displayed in a user-friendly, read-only format during location addition.
  * Enhanced map interaction for a more intuitive user experience when adding locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->